### PR TITLE
Change roulette to only work for managers

### DIFF
--- a/basicBot.js
+++ b/basicBot.js
@@ -2937,7 +2937,7 @@
 
             rouletteCommand: {
                 command: 'roulette',
-                rank: 'mod',
+                rank: 'manager',
                 type: 'exact',
                 functionality: function (chat, cmd) {
                     if (this.type === 'exact' && chat.message.length !== cmd.length) return void (0);


### PR DESCRIPTION
Only managers can start roulette now, even on bouncer+
