### PR TITLE
Update basicBot.js

### DIFF
--- a/basicBot.js
+++ b/basicBot.js
@@ -2360,7 +2360,7 @@
 
             kickCommand: {
                 command: 'kick',
-                rank: 'bouncer',
+                rank: 'host',
                 type: 'startsWith',
                 functionality: function (chat, cmd) {
                     if (this.type === 'exact' && chat.message.length !== cmd.length) return void (0);


### PR DESCRIPTION
Changed the !kick command permission to host only since BB isn't unbanning afterwords. Bouncers are using this to kick autojoiners who keep joining after BB removes them, and people are wondering what's up when they can't come back the following day.
