### PR TITLE
Allowsong command

### DIFF
--- a/basicBot.js
+++ b/basicBot.js
@@ -461,6 +461,16 @@
                 }
                 return false;
             },
+            allowSong: function (name) {
+                for (var i = 0; i < basicBot.room.users.length; i++) {
+                    var match = basicBot.room.users[i].username.trim() == name.trim();
+                    if (match) {
+                        basicBot.room.users[i].allowSong = true;
+                        return basicBot.room.users[i];
+                    }
+                }
+                return false;
+            },
             voteRatio: function (id) {
                 var user = basicBot.userUtilities.lookupUser(id);
                 var votes = user.votes;
@@ -1676,9 +1686,8 @@
                         if (msg.length === cmd.length) return API.sendChat(subChat(basicBot.chat.nouserspecified, {name: chat.un}));
                         var name;
                         name = msg.substring(cmd.length + 2);
-                        var user = basicBot.userUtilities.lookupUserName(name);
+                        var user = basicBot.userUtilities.allowSong(name);
                         if (typeof user === 'boolean') return API.sendChat(subChat(basicBot.chat.invaliduserspecified, {name: chat.un}));
-                        user.allowSong=true;
                         return API.sendChat(subChat(basicBot.chat.allownextsong, {name: user.username}));
                     }
                 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -200,5 +200,6 @@
     "voteratio": "\/me [@%%NAME%%] @%%USERNAME%% ~ woots: %%WOOT%%, mehs: %%MEHS%%, ratio (w\/m): %%RATIO%%.",
     "website": "\/me Please visit our website: %%LINK%%",
     "youtube": "\/me [%%NAME%%] Subscribe to us on youtube: %%LINK%%",
-    "songstatistics": "\/me %%ARTIST%% - %%TITLE%%: %%WOOTS%%W\/%%GRABS%%G\/%%MEHS%%M."
+    "songstatistics": "\/me %%ARTIST%% - %%TITLE%%: %%WOOTS%%W\/%%GRABS%%G\/%%MEHS%%M.",
+    "allownextsong": "\/me Allowing next song by @%%NAME%% to be played over limit."
 }


### PR DESCRIPTION
This PR creates a new !allowsong command that managers (and bouncers on b+) can use to allow a user to play an extended song on his next turn. 
Syntax: "!allowsong @username"
